### PR TITLE
Update suyu.desktop to disable AppImage Launcher

### DIFF
--- a/suyu.desktop
+++ b/suyu.desktop
@@ -3,7 +3,7 @@
 Version=0.0.3
 Name=Suyu
 Comment=Open Source Nintendo Switch Emulator
-Exec=/usr/bin/suyu-bin
+Exec=env APPIMAGELAUNCHER_DISABLE=1 /usr/bin/suyu-bin
 Icon=/usr/share/icons/hicolor/256x256/apps/suyu.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
By default if you have AppImage Launcher installed it prompts you to integrate it to the desktop which is unnecessary in this case. Added the environment variable `APPIMAGELAUNCHER_DISABLE=1` to disable it.